### PR TITLE
Change default password strength message

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,15 @@ class User
 end
 ```
 
-The default validation message is "%{attribute} is too weak".  If you would like to customize that you can override it in your locale file
-by setting a value for this key:
+The default validation message is "is too weak". Rails will display a field of `:password` having too weak of a password with `full_error_messages` as "Password is too weak". If you would like to customize the error message, you can override it in your locale file by setting a value for this key:
+
 
 ```yml
 en:
   errors:
     messages:
       password:
-        password_strength: "%{attribute} is a terrible password, try again!"
+        password_strength: "is a terrible password, try again!"
 ```
 
 ### Standalone

--- a/README.md
+++ b/README.md
@@ -152,10 +152,16 @@ disallowed by the strength checker.
    dictionary of the English language but not so much when you're only talking about the 500 most
    common passwords.
 
+## Running the tests
+
+To run the tests, install the gems with `bundle install`. Then run `rake`.
+
 ## Contributing
 
 1. Fork it
 2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
+3. Make your changes
+4. Test the changes and make sure existing tests pass
+5. Commit your changes (`git commit -am 'Add some feature'`)
+6. Push to the branch (`git push origin my-new-feature`)
+7. Create new Pull Request

--- a/lib/strong_password/locale/en.yml
+++ b/lib/strong_password/locale/en.yml
@@ -2,4 +2,4 @@ en:
   errors:
     messages:
       password:
-        password_strength: "%{attribute} is too weak"
+        password_strength: "is too weak"

--- a/spec/validation/strength_validator_spec.rb
+++ b/spec/validation/strength_validator_spec.rb
@@ -47,7 +47,7 @@ module ActiveModel
               it "adds errors when password is '#{password}'" do
                 base_strength.password = password
                 base_strength.valid?
-                expect(base_strength.errors[:password]).to eq(["Password is too weak"])
+                expect(base_strength.errors[:password]).to eq(["is too weak"])
               end
             end
           end
@@ -79,7 +79,7 @@ module ActiveModel
               it "adds errors when password is '#{password}'" do
                 alternative_usage.password = password
                 alternative_usage.valid?
-                expect(alternative_usage.errors[:password]).to eq(["Password is too weak"])
+                expect(alternative_usage.errors[:password]).to eq(["is too weak"])
               end
             end
           end
@@ -129,7 +129,7 @@ module ActiveModel
                 it "'#{password}' should be invalid with increased entropy requirement" do
                   strong_entropy.password = password
                   strong_entropy.valid?
-                  expect(strong_entropy.errors[:password]).to eq(["Password is too weak"])
+                  expect(strong_entropy.errors[:password]).to eq(["is too weak"])
                 end
               end
             end


### PR DESCRIPTION
Hi Brian! Thanks for making this gem, we are probably going to use it on my current project.

As I was exploring it, I found one thing that was a small issue for us. You have a workaround for it with the locale file documentation, but I was wondering if it would be better to change the default.

Currently, when we use something like `user.errors.full_messages` for a field named `:password` when there are password strength issues, we get something like: `"Password Password is too weak"`

I think that we should follow what seems like the Rails convention of specifying what the error is without the attribute name in the locale file. This follows more closely the pattern in:

http://guides.rubyonrails.org/active_record_validations.html#valid-questionmark-and-invalid-questionmark

By changing the locale string to "is too weak", we correctly get "Password is too weak" when there is a password strength issue."

What do you think about this change? I realize that it would mostly be a breaking change as far as the error message and would probably require a new release of some sort. Locally I will use the locale file override, but wanted to try to contribute back. :)

For the second commit, I added some documentation on how to run the tests. At first I tried `rake`, and then consulting the documentation, and then hit upon `rspec` as the way to run the tests.

Hope this helps!
