### PR TITLE
Use gsub instead of sub in DictionnaryAdjuster

### DIFF
--- a/lib/strong_password/dictionary_adjuster.rb
+++ b/lib/strong_password/dictionary_adjuster.rb
@@ -993,7 +993,7 @@ module StrongPassword
       min_entropy = EntropyCalculator.calculate(base_password)
       # Process the passwords, while looking for possible matching words in the dictionary.
       PasswordVariants.all_variants(base_password).inject( min_entropy ) do |min_entropy, variant|
-        [ min_entropy, EntropyCalculator.calculate( variant.sub( dictionary_words, '*' ) ) ].min 
+        [ min_entropy, EntropyCalculator.calculate( variant.gsub( dictionary_words, '' ) ) ].min 
       end
     end
   end


### PR DESCRIPTION
Strange behavior with sub :
suppose dictionary = ["first_name","last_name"]
if password is "first_name" => take entropy of "_"
if password is "first_name last_name" => take entropy of "_ last_name"
