### PR TITLE
Fix ruby 2.7 warning

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+## v0.0.9
+* jfabre - Remove ruby 2.7 warning
 ## v0.0.8
 This release breaks backwards compatibility if you are using the lib components
 directly. If you are using the ActiveModel validations in a Rails project then

--- a/lib/active_model/validations/password_strength_validator.rb
+++ b/lib/active_model/validations/password_strength_validator.rb
@@ -4,7 +4,7 @@ module ActiveModel
   module Validations
     class PasswordStrengthValidator < ActiveModel::EachValidator
       def validate_each(object, attribute, value)
-        ps = ::StrongPassword::StrengthChecker.new(strength_options(options, object))
+        ps = ::StrongPassword::StrengthChecker.new(**strength_options(options, object))
         unless ps.is_strong?(value.to_s)
           object.errors.add(attribute, :'password.password_strength', options.merge(:value => value.to_s))
         end

--- a/lib/strong_password/version.rb
+++ b/lib/strong_password/version.rb
@@ -1,3 +1,3 @@
 module StrongPassword
-  VERSION = '0.0.8'.freeze
+  VERSION = '0.0.9'.freeze
 end


### PR DESCRIPTION
Ruby 2.7 leaves warnings when hashes are passed as named parameters without double splat operator.
Please let me know if I need to include something else or make a PR on another branch.