### PR TITLE
Update README.md gem version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ NOTE: StrongPassword requires the use of Ruby 2.0.  Upgrade if you haven't alrea
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'strong_password', '~> 0.0.9'
+gem 'strong_password', '~> 0.0.10'
 ```
 
 And then execute:


### PR DESCRIPTION
It seems like it would be a good idea to update the suggested gem version in the installation instructions to the latest version, which is `0.0.10`. What do you think?